### PR TITLE
days/months/years options in wis2box-webapp

### DIFF
--- a/src/components/DatasetEditorForm.vue
+++ b/src/components/DatasetEditorForm.vue
@@ -861,7 +861,10 @@ export default defineComponent({
         // Time durations for resolution
         const durations = [
             { name: 'minutes(s)', code: 'M' },
-            { name: 'hour(s)', code: 'H' }
+            { name: 'hour(s)', code: 'H' },
+            { name: 'day(s)', code: 'D' },
+            { name: 'month(s)', code: 'M' },
+            { name: 'year(s)', code: 'Y' }
         ];
 
         // WCMP2 schema version


### PR DESCRIPTION
For wis2box-issue: https://github.com/World-Meteorological-Organization/wis2box/issues/888

This fix adds the dropdown based on feedback from Jose when testing RC1:
![image](https://github.com/user-attachments/assets/b09fc2a3-3e66-41fe-93b8-3f7d47b069e4)

Using the following mapping between label and code:
```
// Time durations for resolution
        const durations = [
            { name: 'minutes(s)', code: 'M' },
            { name: 'hour(s)', code: 'H' },
            { name: 'day(s)', code: 'D' },
            { name: 'month(s)', code: 'M' },
            { name: 'year(s)', code: 'Y' }
        ];
```