### PR TITLE
Fix: prevent ':' in Local ID to avoid identifier prefix corruption

### DIFF
--- a/src/components/DatasetEditorForm.vue
+++ b/src/components/DatasetEditorForm.vue
@@ -1303,6 +1303,7 @@ export default defineComponent({
             localID.value = value
                 .trim()
                 .toLowerCase()
+                .replace(/:/g, '')
                 .replace(/\s+/g, '-');
             };
 

--- a/src/components/DatasetEditorForm.vue
+++ b/src/components/DatasetEditorForm.vue
@@ -1023,12 +1023,6 @@ export default defineComponent({
                 return ""; // Fallback empty string
             }
             const prefix = `urn:wmo:md:${centreID}:`;
-            if (!identifier.startsWith(prefix)) {
-                console.warn(
-                    `Identifier "${identifier}" does not start with expected prefix "${prefix}".`
-                );
-                return "";
-            }
             return identifier.slice(prefix.length);
         };
 


### PR DESCRIPTION
Add logic to avoid bug happen:
when user input ":", replace to "", which mean user can not enter ":" when they define their Local ID:
Adding input logic for the Local ID field.
When a user types colon or/ colons, then replacing colon or/ colons to "" to avoid identifier prefix corruption.
<img width="523" height="384" alt="image" src="https://github.com/user-attachments/assets/8d240812-f6e0-4ff4-ae80-6362cd41b518" />
<img width="517" height="386" alt="image" src="https://github.com/user-attachments/assets/b1ba894a-2998-4cfc-b3e7-02660f256480" />


