### PR TITLE
add GTS headers functionality with validation for TTAAii and CCCC

### DIFF
--- a/src/components/SynopForm.vue
+++ b/src/components/SynopForm.vue
@@ -308,8 +308,8 @@ export default defineComponent({
             let disabled = (datePossible.value === false) || !bulletin.value || !aaxxPresent.value || !equalsPresent.value || !datasetSelected.value || !token.value;
             // If GTS headers are enabled, validate TTAAii and CCCC
             if (addGTSHeaders.value) {
-                // TTAAiiRule and CCCCRule must both return true (not just truthy)
-                if (TTAAiiRule(TTAAii.value) !== true || CCCCRule(cccc.value) !== true) {
+                // Require both fields to be non-empty and valid
+                if (!TTAAii.value || !cccc.value || TTAAiiRule(TTAAii.value) !== true || CCCCRule(cccc.value) !== true) {
                     disabled = true;
                 }
             }

--- a/src/components/SynopForm.vue
+++ b/src/components/SynopForm.vue
@@ -77,6 +77,30 @@
                                     <v-checkbox :disabled="submitDisabled" v-model="notificationsOnPending"
                                         label="Publish on WIS2" hide-details></v-checkbox>
                                 </v-col>
+                                <v-col cols="2">
+                                    <v-checkbox v-model="addGTSHeaders"
+                                        label="Add GTS headers" hide-details></v-checkbox>
+                                </v-col>
+                            </v-row>
+                            <v-row v-if="addGTSHeaders" class="mt-2">
+                                <v-col cols="3">
+                                    <v-text-field
+                                        label="TTAAii"
+                                        v-model="TTAAii"
+                                        variant="outlined"
+                                        :rules="[TTAAiiRule]"
+                                        @input="e => capitalizeInput(e, 'TTAAii')"
+                                    ></v-text-field>
+                                </v-col>
+                                <v-col cols="3">
+                                    <v-text-field
+                                        label="CCCC"
+                                        v-model="cccc"
+                                        variant="outlined"
+                                        :rules="[CCCCRule]"
+                                        @input="e => capitalizeInput(e, 'cccc')"
+                                    ></v-text-field>
+                                </v-col>
                             </v-row>
                         </v-container>
                     </v-card-item>
@@ -237,6 +261,11 @@ export default defineComponent({
     setup() {
         // Reactive variables
 
+        // GTS headers logic
+        const addGTSHeaders = ref(false);
+        const TTAAii = ref("");
+        const cccc = ref("");
+
         // Current month/year to compare against user selection
         const date = ref({
             month: new Date().getUTCMonth(),
@@ -275,7 +304,16 @@ export default defineComponent({
 
         // Boolean for whether the submit button is disabled or not
         const submitDisabled = computed(() => {
-            return (datePossible.value === false) || !bulletin.value || !aaxxPresent.value || !equalsPresent.value || !datasetSelected.value || !token.value
+            // Basic checks
+            let disabled = (datePossible.value === false) || !bulletin.value || !aaxxPresent.value || !equalsPresent.value || !datasetSelected.value || !token.value;
+            // If GTS headers are enabled, validate TTAAii and CCCC
+            if (addGTSHeaders.value) {
+                // TTAAiiRule and CCCCRule must both return true
+                if (!TTAAiiRule(TTAAii.value) || !CCCCRule(cccc.value)) {
+                    disabled = true;
+                }
+            }
+            return disabled;
         })
 
         // Computes the result title re: success, partial success, or failure
@@ -408,6 +446,11 @@ export default defineComponent({
                     notify: notificationsOn.value // Boolean for WIS2 notifications
                 }
             };
+            // Add GTS headers if enabled
+            if (addGTSHeaders.value) {
+                payload.inputs.gts_ttaaii = TTAAii.value;
+                payload.inputs.gts_cccc = cccc.value;
+            }
             let headers = {
                 'encode': 'json',
                 'Content-Type': 'application/geo+json',
@@ -492,6 +535,33 @@ export default defineComponent({
             }
         }, { deep: true });
 
+        // TTAAii must be exactly 4 latin characters followed by 2 digits
+        const TTAAiiRule = v => {
+            if (!v) return true;
+            return /^[a-zA-Z]{4}\d{2}$/.test(v) || 'TTAAii must be 4 letters followed by 2 digits';
+        };
+
+        // CCCC must be exactly 4 alphanumeric characters
+        const CCCCRule = v => {
+            if (!v) return true;
+            return /^[a-zA-Z0-9]{4}$/.test(v) || 'CCCC must be 4 characters';
+        };
+
+        // Auto-capitalize input for TTAAii and CCCC fields
+        const capitalizeInput = (e, field) => {
+            let val = '';
+            if (typeof e === 'string') {
+                val = e.toUpperCase();
+            } else if (e && e.target && typeof e.target.value === 'string') {
+                val = e.target.value.toUpperCase();
+            }
+            if (field === 'TTAAii') {
+                TTAAii.value = val;
+            } else if (field === 'cccc') {
+                cccc.value = val;
+            }
+        };
+
         return {
             date,
             datePossible,
@@ -514,7 +584,13 @@ export default defineComponent({
             numberNotifications,
             checkMessage,
             scrollToRef,
-            submit
+            submit,
+            addGTSHeaders,
+            TTAAii,
+            cccc,
+            TTAAiiRule,
+            CCCCRule,
+            capitalizeInput,
         }
     }
 })

--- a/src/components/SynopForm.vue
+++ b/src/components/SynopForm.vue
@@ -309,7 +309,7 @@ export default defineComponent({
             // If GTS headers are enabled, validate TTAAii and CCCC
             if (addGTSHeaders.value) {
                 // Require both fields to be non-empty and valid
-                if (!TTAAii.value || !cccc.value || TTAAiiRule(TTAAii.value) !== true || CCCCRule(cccc.value) !== true) {
+                if (TTAAiiRule(TTAAii.value) !== true || CCCCRule(cccc.value) !== true) {
                     disabled = true;
                 }
             }

--- a/src/components/SynopForm.vue
+++ b/src/components/SynopForm.vue
@@ -308,8 +308,8 @@ export default defineComponent({
             let disabled = (datePossible.value === false) || !bulletin.value || !aaxxPresent.value || !equalsPresent.value || !datasetSelected.value || !token.value;
             // If GTS headers are enabled, validate TTAAii and CCCC
             if (addGTSHeaders.value) {
-                // TTAAiiRule and CCCCRule must both return true
-                if (!TTAAiiRule(TTAAii.value) || !CCCCRule(cccc.value)) {
+                // TTAAiiRule and CCCCRule must both return true (not just truthy)
+                if (TTAAiiRule(TTAAii.value) !== true || CCCCRule(cccc.value) !== true) {
                     disabled = true;
                 }
             }


### PR DESCRIPTION
In support of https://github.com/World-Meteorological-Organization/wis2box/issues/1078
This adds the option to provide GTS headers as input in the wis2box-webapp synop form

New option "Add GTS headers", disabled by default :
<img width="1316" height="820" alt="image" src="https://github.com/user-attachments/assets/14988c5e-7efa-47a0-83a2-d765a36db1ca" />

When option "Add GTS headers" is enabled by user, two new input-boxes appear, with valid input required:
<img width="1301" height="908" alt="image" src="https://github.com/user-attachments/assets/1ceb1459-8857-4d89-a171-e19b9c364ac1" />
