### PR TITLE
set missing items to undefined instead of empty string for host-details

### DIFF
--- a/src/components/DatasetEditorForm.vue
+++ b/src/components/DatasetEditorForm.vue
@@ -1755,16 +1755,16 @@ export default defineComponent({
                     individual: contact.name,
                     positionName: contact.position,
                     name: contact.organization,
-                    phone: contact.phones ? contact.phones[0].value : '',
-                    email: contact.emails ? contact.emails[0].value : '',
-                    deliveryPoint: contact.addresses ? contact.addresses[0].deliveryPoint : '',
-                    city: contact.addresses ? contact.addresses[0].city : '',
-                    administrativeArea: contact.addresses ? contact.addresses[0].administrativeArea : '',
-                    postalCode: contact.addresses ? contact.addresses[0].postalCode : '',
-                    country: contact.addresses ? contact.addresses[0].country : '',
+                    phone: contact.phones ? contact.phones[0].value : undefined,
+                    email: contact.emails ? contact.emails[0].value : undefined,
+                    deliveryPoint: contact.addresses ? contact.addresses[0].deliveryPoint : undefined,
+                    city: contact.addresses ? contact.addresses[0].city : undefined,
+                    administrativeArea: contact.addresses ? contact.addresses[0].administrativeArea : undefined,
+                    postalCode: contact.addresses ? contact.addresses[0].postalCode : undefined,
+                    country: contact.addresses ? contact.addresses[0].country : undefined,
                     hoursOfService: contact.hoursOfService,
                     contactInstructions: contact.contactInstructions,
-                    url: contact.links ? contact.links[0].href : ''
+                    url: contact.links ? contact.links[0].href : undefined
                 };
             }
             schema.properties.contacts.forEach(contact => {


### PR DESCRIPTION
Currently the dataset-editor is unable to edit a record created after publishing this MCF used in the wis2box automated tests due to the null entries in host contact details:
https://github.com/World-Meteorological-Organization/wis2box/blob/main/tests/data/metadata/discovery/dz-surface-weather-observations.yml

This results in the following error when attempting to update and publish such a record from the dataset-editor:
```
[2026-06-23T10:49:00Z] {/app/venv/lib/python3.12/site-packages/pywcmp/wcmp2/ets.py:109} ERROR - ('Record fails WCMP2 validation. Stopping ETS ', 'errors: ["$.properties.contacts[0].addresses[0].deliveryPoint: \'\' is not of type \'array\'"]')
[2026-06-23T10:49:00Z] {/app/wis2box/pubsub/subscribe.py:203} ERROR - Failed to publish discovery metadata: ('Record fails WCMP2 validation. Stopping ETS ', 'errors: ["$.properties.contacts[0].addresses[0].deliveryPoint: \'\' is not of type \'array\'"]')
wis2box.cron is alive
```

This PR addresses this issue by setting undefined all fields that can not be defined from the input